### PR TITLE
Shippable: Replace cron rule by weekly executions

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -43,8 +43,7 @@ resources:
   - name: canvas-cpn-weekly-trigger
     type: time
     versionTemplate:
-      # interval: "0 0 * * MON"  # this field accepts cron like syntax
-      interval: "0 * * * *" # This is for testing purposes, test the automatic build every hour.
+      interval: "0 0 * * MON"  # this field accepts cron like syntax
 
 jobs:
   - name: canvas-where-am-I-weekly_runCI


### PR DESCRIPTION
For testing purposes I enabled a cron rule to perform the build every hour, it works fine:

![image](https://user-images.githubusercontent.com/8653754/94908537-1b0d4680-04a2-11eb-8eeb-67dc6b8039f7.png)

This PR meets the requirements and expectations, perform the tests every monday.