### PR TITLE
IH013-60 - ADR_10273-17 - Unordered list not marked up semantically

### DIFF
--- a/canvas-where-am-I.css
+++ b/canvas-where-am-I.css
@@ -294,9 +294,3 @@ li.ou-menu-item-wrapper a {
 /********************************************************************************
  * End of Canvas Theme Overrides
 *********************************************************************************/
-
-.unstyled-list {
-  list-style: none;
-  margin-left: 0;
-  padding-left: 0;
-}

--- a/canvas-where-am-I.js
+++ b/canvas-where-am-I.js
@@ -236,6 +236,7 @@
         if (mindex % noOfColumnsPerRow === 0) {
             newRow = document.createElement('div');
             newRow.className = 'grid-row center-sm';
+            moduleNav.appendChild(newRow);
         }
 
         var newColumn = document.createElement('div');
@@ -274,6 +275,7 @@
         moduleTileLink.appendChild(moduleTileHeader);
         moduleTileLink.appendChild(moduleTileContent);
         moduleTile.appendChild(moduleTileLink);
+        newColumn.appendChild(moduleTile);
 
       });
 

--- a/canvas-where-am-I.js
+++ b/canvas-where-am-I.js
@@ -230,17 +230,12 @@
       moduleNavAnchorLink.id = 'module_nav_anchor';
       moduleNav.appendChild(moduleNavAnchorLink);
 
-      const ul = document.createElement('ul');
-      ul.className = 'unstyled-list';
-      moduleNav.appendChild(ul);
-
       let newRow;
       moduleArray.forEach((module, mindex) => {
         //create row for card
         if (mindex % noOfColumnsPerRow === 0) {
             newRow = document.createElement('div');
             newRow.className = 'grid-row center-sm';
-            ul.appendChild(newRow);
         }
 
         var newColumn = document.createElement('div');
@@ -248,8 +243,6 @@
         // create column wrapper
         newColumn.className = 'col-xs-12 col-sm-6 col-lg-3';
         newRow.appendChild(newColumn);
-
-        let li = document.createElement('li');
 
         //create module div
         let moduleTile = document.createElement('div');
@@ -281,8 +274,6 @@
         moduleTileLink.appendChild(moduleTileHeader);
         moduleTileLink.appendChild(moduleTileContent);
         moduleTile.appendChild(moduleTileLink);
-        li.appendChild(moduleTile);
-        newColumn.appendChild(li);
 
       });
 


### PR DESCRIPTION
 * revert changes

Axe assesses a "serious" issue:

“\<ul> and \<ol> must only directly contain \<li>, \<script> or \<template> elements”

Because every set of four tiles is wrapped in a row element, I don’t think we can fix this:

```
<ul class="unstyled-list">
  <div class="grid-row center-sm">
    <li>
      <div class="tile">

```